### PR TITLE
Use node24 for action runtime

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: false
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"
 
 branding:


### PR DESCRIPTION
## Summary
- switch the action runtime in `action.yml` from `node20` to `node24`
- address the GitHub Actions runtime deprecation tracked in #26

## Testing
- pnpm test

Closes #26