### PR TITLE
Bump action version to v1.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-tombi",
-  "version": "1.0.1",
+  "version": "1.0.9",
   "private": true,
   "description": "GitHub Action to set up Tombi",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump the package version from `1.0.1` to `1.0.9`
- prepare the next patch release tag after the node24 runtime change

## Testing
- not run (version metadata only)