### PR TITLE
Remove unnecessary GITHUB_TOKEN usage examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,6 @@ jobs:
         uses: ./
         with:
           version: latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify tombi is installed
         run: tombi --version
@@ -68,9 +66,7 @@ jobs:
       - name: Test action with specific version
         uses: ./
         with:
-          version: "0.7.11"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          version: "0.9.20"
 
       - name: Verify specific version is installed
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,8 @@ jobs:
         run: |
           VERSION=$(tombi --version)
           echo "Installed version: $VERSION"
-          if [[ "$VERSION" != *"0.7.11"* ]]; then
-            echo "Expected version 0.7.11 but got $VERSION"
+          if [[ "$VERSION" != *"0.9.20"* ]]; then
+            echo "Expected version 0.9.20 but got $VERSION"
             exit 1
           fi
         shell: bash

--- a/.github/workflows/market-place-test.yml
+++ b/.github/workflows/market-place-test.yml
@@ -27,8 +27,5 @@ jobs:
       - uses: tombi-toml/setup-tombi@v1
         with:
           version: ${{ matrix.version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Verify tombi is installed
         run: tombi --version

--- a/README.md
+++ b/README.md
@@ -8,16 +8,12 @@ This action sets up [Tombi](https://github.com/tombi-toml/tombi) in your GitHub 
 
 ```yaml
 - uses: tombi-toml/setup-tombi@v1
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### Install a specific version
 
 ```yaml
 - uses: tombi-toml/setup-tombi@v1
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
     version: '0.9.20'
 ```
@@ -26,8 +22,6 @@ This action sets up [Tombi](https://github.com/tombi-toml/tombi) in your GitHub 
 
 ```yaml
 - uses: tombi-toml/setup-tombi@v1
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
     lockfile: 'uv.lock'
 ```
@@ -36,8 +30,6 @@ This action sets up [Tombi](https://github.com/tombi-toml/tombi) in your GitHub 
 
 ```yaml
 - uses: tombi-toml/setup-tombi@v1
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
     version: '0.9.20'
     checksum: 'sha256-checksum-here'
@@ -71,8 +63,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: tombi-toml/setup-tombi@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           version: '0.9.20'
       - name: Validate TOML files


### PR DESCRIPTION
This removes GITHUB_TOKEN from the README and workflow examples because the action does not require callers to pass it explicitly. It also updates the pinned version in the CI workflow from 0.7.11 to 0.9.20 to match the current documented release. This PR addresses issue #29. The marketplace test workflow keeps covering matrix versions without the extra env wiring.