### PR TITLE
refactor: address cache review feedback

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -41033,11 +41033,10 @@ exports.STATE_CACHE_PATH = "cache-path";
 const CACHE_VERSION = "v1";
 function parseCacheMode(input) {
     const normalized = input.trim().toLowerCase();
-    if (normalized === "" ||
-        normalized === "auto" ||
+    if (normalized === "auto" ||
         normalized === "true" ||
         normalized === "false") {
-        return (normalized || "auto");
+        return normalized;
     }
     throw new Error('Input `enable-cache` must be one of "true", "false", or "auto".');
 }
@@ -41078,9 +41077,18 @@ async function restoreTombiCache(keyPart) {
     core.saveState(exports.STATE_CACHE_ENABLED, "true");
     core.saveState(exports.STATE_CACHE_KEY, cacheKey);
     core.saveState(exports.STATE_CACHE_PATH, cacheDir);
-    const restoredKey = await cache.restoreCache([cacheDir], cacheKey, [
-        `${createBaseCacheKey()}-`,
-    ]);
+    let restoredKey;
+    try {
+        restoredKey = await cache.restoreCache([cacheDir], cacheKey, [
+            `${createBaseCacheKey()}-`,
+        ]);
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to restore Tombi cache.";
+        core.warning(message);
+        core.setOutput("cache-hit", "false");
+        return;
+    }
     if (!restoredKey) {
         core.info(`No GitHub Actions cache found for key: ${cacheKey}`);
         core.setOutput("cache-hit", "false");

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -40130,11 +40130,10 @@ exports.STATE_CACHE_PATH = "cache-path";
 const CACHE_VERSION = "v1";
 function parseCacheMode(input) {
     const normalized = input.trim().toLowerCase();
-    if (normalized === "" ||
-        normalized === "auto" ||
+    if (normalized === "auto" ||
         normalized === "true" ||
         normalized === "false") {
-        return (normalized || "auto");
+        return normalized;
     }
     throw new Error('Input `enable-cache` must be one of "true", "false", or "auto".');
 }
@@ -40175,9 +40174,18 @@ async function restoreTombiCache(keyPart) {
     core.saveState(exports.STATE_CACHE_ENABLED, "true");
     core.saveState(exports.STATE_CACHE_KEY, cacheKey);
     core.saveState(exports.STATE_CACHE_PATH, cacheDir);
-    const restoredKey = await cache.restoreCache([cacheDir], cacheKey, [
-        `${createBaseCacheKey()}-`,
-    ]);
+    let restoredKey;
+    try {
+        restoredKey = await cache.restoreCache([cacheDir], cacheKey, [
+            `${createBaseCacheKey()}-`,
+        ]);
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to restore Tombi cache.";
+        core.warning(message);
+        core.setOutput("cache-hit", "false");
+        return;
+    }
     if (!restoredKey) {
         core.info(`No GitHub Actions cache found for key: ${cacheKey}`);
         core.setOutput("cache-hit", "false");

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "build": "rm -rf dist && ncc build src/index.ts -o dist && ncc build src/post.ts -o dist/post",
+    "build": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && ncc build src/index.ts -o dist && ncc build src/post.ts -o dist/post",
     "format": "biome format --fix",
     "format-check": "biome format",
     "lint": "biome lint --fix",

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -74,9 +74,18 @@ export async function restoreTombiCache(keyPart: string): Promise<void> {
   core.saveState(STATE_CACHE_KEY, cacheKey);
   core.saveState(STATE_CACHE_PATH, cacheDir);
 
-  const restoredKey = await cache.restoreCache([cacheDir], cacheKey, [
-    `${createBaseCacheKey()}-`,
-  ]);
+  let restoredKey: string | undefined;
+  try {
+    restoredKey = await cache.restoreCache([cacheDir], cacheKey, [
+      `${createBaseCacheKey()}-`,
+    ]);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to restore Tombi cache.";
+    core.warning(message);
+    core.setOutput("cache-hit", "false");
+    return;
+  }
 
   if (!restoredKey) {
     core.info(`No GitHub Actions cache found for key: ${cacheKey}`);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -162,6 +162,22 @@ describe("setup-tombi action", () => {
       );
     });
 
+    it("warns and continues when cache restore fails", async () => {
+      vi.mocked(cache.restoreCache).mockRejectedValue(
+        new Error("cache backend unavailable"),
+      );
+
+      await runAction();
+
+      expect(core.warning).toHaveBeenCalledWith("cache backend unavailable");
+      expect(core.setOutput).toHaveBeenCalledWith("cache-hit", "false");
+      expect(execSyncMock).toHaveBeenCalledWith(
+        `bash "${mockScriptPath}" --version latest --install-dir "/home/user/.local/bin"`,
+        { stdio: "inherit" },
+      );
+      expect(core.setFailed).not.toHaveBeenCalled();
+    });
+
     it("skips cache restore when disabled", async () => {
       setInputs({ "enable-cache": "false" });
 


### PR DESCRIPTION
## Summary
Address the valid review feedback from PR #31.
Make cache restore best-effort by warning and continuing when `@actions/cache.restoreCache` fails, instead of failing the whole setup action.
Replace the Unix-only `rm -rf dist` build cleanup with a cross-platform Node `fs.rmSync` call, and add test coverage for the cache-restore failure path.

## Validation
`pnpm test`
`pnpm run format-check`
`pnpm build`
