### PR TITLE
Sync package version before retagging

### DIFF
--- a/.github/workflows/update-major-minor-tags.yml
+++ b/.github/workflows/update-major-minor-tags.yml
@@ -16,6 +16,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Update Major Minor Tags
         run: |
           set -x
@@ -26,6 +28,8 @@ jobs:
           TAG="${GITHUB_REF#refs/tags/}" # v1.2.3
           MINOR="${TAG%.*}"              # v1.2
           MAJOR="${MINOR%.*}"            # v1
+          VERSION="${TAG#v}"             # 1.2.3
+          export VERSION
 
           if [ "${GITHUB_REF}" = "${TAG}" ]; then
             echo "This workflow is not triggered by tag push: GITHUB_REF=${GITHUB_REF}"
@@ -38,6 +42,23 @@ jobs:
           # Set up Git.
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+          # Sync package.json version on main with the pushed release tag.
+          git fetch origin main
+          git checkout -B main origin/main
+          node -e '
+            const fs = require("node:fs");
+            const path = "package.json";
+            const pkg = JSON.parse(fs.readFileSync(path, "utf8"));
+            pkg.version = process.env.VERSION;
+            fs.writeFileSync(path, `${JSON.stringify(pkg, null, 2)}\n`);
+          '
+
+          if ! git diff --quiet -- package.json; then
+            git add package.json
+            git commit -m "Update package version to ${TAG}"
+            git push origin main
+          fi
 
           # Update MAJOR/MINOR tag
           git tag -fa "${MAJOR}" -m "${MESSAGE}"

--- a/.github/workflows/update-major-minor-tags.yml
+++ b/.github/workflows/update-major-minor-tags.yml
@@ -3,8 +3,6 @@ name: Update Major Minor Tags
 
 on:
   push:
-    branches:
-      - main
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 
@@ -16,8 +14,9 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          fetch-depth: 0
+          node-version-file: ".node-version"
       - name: Update Major Minor Tags
         run: |
           set -x
@@ -31,20 +30,22 @@ jobs:
           VERSION="${TAG#v}"             # 1.2.3
           export VERSION
 
-          if [ "${GITHUB_REF}" = "${TAG}" ]; then
-            echo "This workflow is not triggered by tag push: GITHUB_REF=${GITHUB_REF}"
-            echo "Skipping update of major and minor tags"
-            exit 0
-          fi
-
           MESSAGE="Release ${TAG}"
 
           # Set up Git.
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
+          git fetch origin main "refs/tags/${TAG}:refs/tags/${TAG}"
+          MAIN_SHA="$(git rev-parse origin/main)"
+          TAG_SHA="$(git rev-list -n 1 "${TAG}")"
+
+          if [ "${MAIN_SHA}" != "${TAG_SHA}" ]; then
+            echo "Refusing to update main: tag ${TAG} (${TAG_SHA}) does not match origin/main (${MAIN_SHA})"
+            exit 1
+          fi
+
           # Sync package.json version on main with the pushed release tag.
-          git fetch origin main
           git checkout -B main origin/main
           node -e '
             const fs = require("node:fs");


### PR DESCRIPTION
## Summary
This updates the release-tag workflow so a tag push first syncs `package.json`'s `version` on `main` to the pushed release version. If that changes `package.json`, the workflow commits and pushes `main` before force-updating the moving `vX` and `vX.Y` tags.

## Why
Without this, the major and minor tags can move to a commit where `package.json` still reports the previous version.

## Validation
I reviewed `git diff origin/main...` and confirmed the PR diff is limited to `.github/workflows/update-major-minor-tags.yml`.
