### PR TITLE
Clarify enable-cache behavior in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,11 @@ This action sets up [Tombi](https://github.com/tombi-toml/tombi) in your GitHub 
 
 By default, `enable-cache` is `auto`.
 
-- On GitHub-hosted runners, cache is enabled automatically.
-- On self-hosted runners, cache is disabled automatically.
+- `true` always enables cache.
+- `false` always disables cache.
+- `auto` enables cache unless the runner environment is `self-hosted`.
+  On GitHub-hosted runners, cache is enabled automatically.
+  On self-hosted runners, cache is disabled automatically.
 
 Use `enable-cache: true` only when you want to force cache on, for example on self-hosted runners.
 


### PR DESCRIPTION
Clarifies the README documentation for `enable-cache` by defining the behavior of `true`, `false`, and `auto`.

`auto` is now described explicitly as enabling cache unless the runner environment is `self-hosted`, matching the current implementation.

Validation: reviewed the docs diff only; no code changes or tests were needed.
