### PR TITLE
Unify release tag and version sync workflows

### DIFF
--- a/.github/workflows/update-major-minor-tags.yml
+++ b/.github/workflows/update-major-minor-tags.yml
@@ -4,7 +4,7 @@ name: Update Major Minor Tags
 on:
   push:
     tags:
-      - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]*.[0-9]*.[0-9]*
 
 jobs:
   update-major-minor-tags:

--- a/.github/workflows/update-major-minor-tags.yml
+++ b/.github/workflows/update-major-minor-tags.yml
@@ -8,62 +8,42 @@ on:
 
 jobs:
   update-major-minor-tags:
-    name: Make sure major and minor tags are up to date on a patch release
+    name: Update major/minor tags
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
         with:
-          node-version-file: ".node-version"
-      - name: Update Major Minor Tags
+          fetch-depth: 0
+      - name: Update major/minor tags
         run: |
-          set -x
+          set -eu
 
           cd "${GITHUB_WORKSPACE}" || exit
 
-          # Set up variables.
+          git fetch origin main --tags
+
           TAG="${GITHUB_REF#refs/tags/}" # v1.2.3
           MINOR="${TAG%.*}"              # v1.2
           MAJOR="${MINOR%.*}"            # v1
-          VERSION="${TAG#v}"             # 1.2.3
-          export VERSION
-
           MESSAGE="Release ${TAG}"
+
+          MAIN_SHA="$(git rev-parse origin/main)"
+          TAG_SHA="$(git rev-list -n 1 "${TAG}")"
+
+          if [ "${MAIN_SHA}" != "${TAG_SHA}" ]; then
+            echo "Refusing to update major/minor tags: tag ${TAG} (${TAG_SHA}) does not match origin/main (${MAIN_SHA})"
+            exit 1
+          fi
 
           # Set up Git.
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
-          git fetch origin main "refs/tags/${TAG}:refs/tags/${TAG}"
-          MAIN_SHA="$(git rev-parse origin/main)"
-          TAG_SHA="$(git rev-list -n 1 "${TAG}")"
-
-          if [ "${MAIN_SHA}" != "${TAG_SHA}" ]; then
-            echo "Refusing to update main: tag ${TAG} (${TAG_SHA}) does not match origin/main (${MAIN_SHA})"
-            exit 1
-          fi
-
-          # Sync package.json version on main with the pushed release tag.
-          git checkout -B main origin/main
-          node -e '
-            const fs = require("node:fs");
-            const path = "package.json";
-            const pkg = JSON.parse(fs.readFileSync(path, "utf8"));
-            pkg.version = process.env.VERSION;
-            fs.writeFileSync(path, `${JSON.stringify(pkg, null, 2)}\n`);
-          '
-
-          if ! git diff --quiet -- package.json; then
-            git add package.json
-            git commit -m "Update package version to ${TAG}"
-            git push origin main
-          fi
-
           # Update MAJOR/MINOR tag
-          git tag -fa "${MAJOR}" -m "${MESSAGE}"
-          git tag -fa "${MINOR}" -m "${MESSAGE}"
+          git tag -fa "${MAJOR}" origin/main -m "${MESSAGE}"
+          git tag -fa "${MINOR}" origin/main -m "${MESSAGE}"
 
           # Push
           git push --force origin "${MINOR}"

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: git config --global user.name 'Github Actions'
+      - run: git config --global user.name 'GitHub Actions'
       - run: git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
       - name: Sync package.json and README.md

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,18 +1,52 @@
 name: Update Version
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to sync into package.json and README.md"
+        required: true
 
 jobs:
   release:
     name: "Update version"
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - run: git config --global user.name 'Github Actions'
       - run: git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-      - run: python3 update_version.py
+      - name: Sync package.json and README.md
+        run: |
+          set -eu
+
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "workflow_dispatch version updates must run from main"
+            exit 1
+          fi
+
+          if [ -z "${INPUT_VERSION}" ]; then
+            echo "inputs.version is required"
+            exit 1
+          fi
+
+          python3 update_version.py --version "${INPUT_VERSION}"
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+
+      - name: Commit and push if needed
+        run: |
+          if git diff --quiet -- package.json README.md; then
+            echo "No version changes to commit"
+            exit 0
+          fi
+
+          VERSION="$(python3 -c 'import json, pathlib; print(json.loads(pathlib.Path("package.json").read_text())["version"])')"
+
+          git add package.json README.md
+          git commit -m "Update version to v${VERSION}"
+          git push origin HEAD

--- a/update_version.py
+++ b/update_version.py
@@ -1,6 +1,6 @@
+import json
 import argparse
 import re
-import json
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent
@@ -27,12 +27,22 @@ def read_package_version() -> str:
 
 def update_package_json(new_version: str) -> bool:
     package_json_path = REPO_ROOT / "package.json"
-    package_json = json.loads(package_json_path.read_text())
-    if package_json["version"] == new_version:
+    package_json_content = package_json_path.read_text()
+    package_json = json.loads(package_json_content)
+    current_version = package_json["version"]
+    if current_version == new_version:
         return False
 
-    package_json["version"] = new_version
-    package_json_path.write_text(f"{json.dumps(package_json, indent=2)}\n")
+    updated_content, replacements = re.subn(
+        r'("version"\s*:\s*")[^"]+(")',
+        rf"\g<1>{new_version}\g<2>",
+        package_json_content,
+        count=1,
+    )
+    if replacements != 1:
+        raise RuntimeError('Could not find "version" field in package.json')
+
+    package_json_path.write_text(updated_content)
     return True
 
 
@@ -48,14 +58,17 @@ def update_readme(new_version: str) -> bool:
 
     current_version = version_match.group(1)
     print(f"Current documented version: {current_version}")
-    if current_version == new_version:
-        return False
 
-    updated_content = re.sub(
+    updated_content, replacements = re.subn(
         r"uses: tombi-toml/setup-tombi@v\d+\.\d+\.\d+",
         f"uses: tombi-toml/setup-tombi@v{new_version}",
         readme_content,
     )
+    if replacements == 0:
+        raise RuntimeError("Could not find setup-tombi version references in README.md")
+    if updated_content == readme_content:
+        return False
+
     readme_path.write_text(updated_content)
     return True
 

--- a/update_version.py
+++ b/update_version.py
@@ -1,17 +1,45 @@
+import argparse
 import re
-import subprocess
 import json
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent
 
 
-def main():
-    package_json_path = REPO_ROOT / "package.json"
-    package_version = json.loads(package_json_path.read_text())["version"]
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Version to sync into package.json and README.md. Accepts both 1.2.3 and v1.2.3.",
+    )
+    return parser.parse_args()
 
+
+def normalize_version(version: str) -> str:
+    return version.removeprefix("v").strip()
+
+
+def read_package_version() -> str:
+    package_json_path = REPO_ROOT / "package.json"
+    return json.loads(package_json_path.read_text())["version"]
+
+
+def update_package_json(new_version: str) -> bool:
+    package_json_path = REPO_ROOT / "package.json"
+    package_json = json.loads(package_json_path.read_text())
+    if package_json["version"] == new_version:
+        return False
+
+    package_json["version"] = new_version
+    package_json_path.write_text(f"{json.dumps(package_json, indent=2)}\n")
+    return True
+
+
+def update_readme(new_version: str) -> bool:
     readme_path = REPO_ROOT / "README.md"
     readme_content = readme_path.read_text()
+
     version_match = re.search(
         r"uses: tombi-toml/setup-tombi@v(\d+\.\d+\.\d+)", readme_content
     )
@@ -20,38 +48,36 @@ def main():
 
     current_version = version_match.group(1)
     print(f"Current documented version: {current_version}")
-    print(f"Package version: {package_version}")
-    if package_version == current_version:
+    if current_version == new_version:
+        return False
+
+    updated_content = re.sub(
+        r"uses: tombi-toml/setup-tombi@v\d+\.\d+\.\d+",
+        f"uses: tombi-toml/setup-tombi@v{new_version}",
+        readme_content,
+    )
+    readme_path.write_text(updated_content)
+    return True
+
+
+def main():
+    args = parse_args()
+    target_version = normalize_version(args.version)
+    current_package_version = read_package_version()
+    print(f"Current package version: {current_package_version}")
+    print(f"Target version: {target_version}")
+
+    package_updated = update_package_json(target_version)
+    readme_updated = update_readme(target_version)
+
+    if not package_updated and not readme_updated:
         print("Versions are already up to date")
         return
 
-    paths = update_version_in_files(package_version)
-    subprocess.run(["git", "add", *paths], check=True)
-    subprocess.run(
-        ["git", "commit", "-m", f"Update version to v{package_version}"],
-        check=True,
-    )
-    subprocess.run(["git", "push", "origin", "HEAD"], check=True)
-
-
-def update_version_in_files(new_version: str) -> tuple[str, ...]:
-    def replace_readme_md(content: str) -> str:
-        content = re.sub(
-            r"uses: tombi-toml/setup-tombi@v\d+\.\d+\.\d+",
-            f"uses: tombi-toml/setup-tombi@v{new_version}",
-            content,
-        )
-        return content
-
-    paths = {
-        "README.md": replace_readme_md,
-    }
-    for path, replacer in paths.items():
-        absolute_path = REPO_ROOT / path
-        updated_content = replacer(content=absolute_path.read_text())
-        absolute_path.write_text(updated_content)
-
-    return tuple(paths.keys())
+    if package_updated:
+        print("Updated package.json")
+    if readme_updated:
+        print("Updated README.md")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This updates the release automation so major/minor tags are moved directly to the `origin/main` release commit instead of mutating `main` during tag handling.
It also changes the manual version workflow to require an explicit version input, sync both `package.json` and `README.md`, and commit only when those files actually change.
In support of that flow, `update_version.py` now accepts `--version`, normalizes `v` prefixes, updates `package.json` and `README.md` independently, and exits cleanly when no sync is needed.
Validation: `python3 -m py_compile update_version.py` and `python3 update_version.py --version "$(python3 -c 'import json, pathlib; print(json.loads(pathlib.Path("package.json").read_text())["version"])' )"`.
