### PR TITLE
[codex] Automate release note generation on version tags

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,31 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - v[0-9]*.[0-9]*.[0-9]*
+
+jobs:
+  create-release:
+    name: Create GitHub release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Create release with generated notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+
+          TAG="${GITHUB_REF#refs/tags/}"
+
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "Release for ${TAG} already exists"
+            exit 0
+          fi
+
+          gh release create "${TAG}" \
+            --verify-tag \
+            --generate-notes \
+            --title "${TAG}"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,13 +12,42 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Create release with generated notes
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -eu
 
+          cd "${GITHUB_WORKSPACE}" || exit
+
           TAG="${GITHUB_REF#refs/tags/}"
+
+          case "${TAG}" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *)
+              echo "Skipping non-release tag: ${TAG}"
+              exit 0
+              ;;
+          esac
+
+          if ! printf '%s\n' "${TAG}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Skipping non-semver release tag: ${TAG}"
+            exit 0
+          fi
+
+          git fetch origin main --tags
+
+          MAIN_SHA="$(git rev-parse origin/main)"
+          TAG_SHA="$(git rev-list -n 1 "${TAG}")"
+
+          if [ "${MAIN_SHA}" != "${TAG_SHA}" ]; then
+            echo "Refusing to create release: tag ${TAG} (${TAG_SHA}) does not match origin/main (${MAIN_SHA})"
+            exit 1
+          fi
 
           if gh release view "${TAG}" >/dev/null 2>&1; then
             echo "Release for ${TAG} already exists"


### PR DESCRIPTION
## Summary
Add a GitHub Actions workflow that creates a GitHub Release automatically when a `vX.Y.Z` tag is pushed.
The workflow uses GitHub's generated release notes and skips creation if the release for that tag already exists, so reruns stay idempotent.
This fills the current gap where version tags updated aliases like `v1` and `v1.1` but did not publish a Release with notes.
Validation: reviewed `git diff origin/main...HEAD` and ran `git diff --check`.
