### PR TITLE
[codex] Link release notes to matching tombi release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,10 +108,18 @@ jobs:
             exit 0
           fi
 
+          VERSION="${TAG#v}"
+          TOMBI_RELEASE_URL="https://github.com/tombi-toml/tombi/releases/tag/v${VERSION}"
+          NOTES=$(cat <<EOF
+          This setup-tombi release matches [tombi v${VERSION}](${TOMBI_RELEASE_URL}).
+          EOF
+          )
+
           gh release create "${TAG}" \
             --target "${RELEASE_SHA}" \
             --verify-tag \
             --generate-notes \
+            --notes "${NOTES}" \
             --title "${TAG}"
 
       - name: Update major/minor tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,10 +110,7 @@ jobs:
 
           VERSION="${TAG#v}"
           TOMBI_RELEASE_URL="https://github.com/tombi-toml/tombi/releases/tag/v${VERSION}"
-          NOTES=$(cat <<EOF
-          This setup-tombi release matches [tombi v${VERSION}](${TOMBI_RELEASE_URL}).
-          EOF
-          )
+          NOTES="This setup-tombi release matches [tombi v${VERSION}](${TOMBI_RELEASE_URL})."
 
           gh release create "${TAG}" \
             --target "${RELEASE_SHA}" \


### PR DESCRIPTION
Adds a short preface to generated GitHub release notes linking to the same-version `tombi` release.
This aligns the release flow with the new policy that `setup-tombi` and `tombi` share version numbers.
Users can jump directly from a `setup-tombi` release to the corresponding `tombi` release page.
Validation: `pnpm test`.
