### PR TITLE
Update README checksum examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,14 @@ This is the recommended form from `setup-tombi@v1.1.0` onward. When `with.versio
 
 ### Install with checksum verification
 
+The checksum examples below are for GitHub-hosted Linux x64 runners (`x86_64-unknown-linux-musl`).
+
 For the archive
 
 ```yaml
 - uses: tombi-toml/setup-tombi@v1.1.4
   with:
-    version: '1.0.0'
-    archive-checksum: '<sha256-checksum>'
+    archive-checksum: '65586fb53f36b989636d2e83e27316d788056835cc7f8e6e38ba445fb17d9b43'
 ```
 
 For the executable binary
@@ -44,8 +45,7 @@ For the executable binary
 ```yaml
 - uses: tombi-toml/setup-tombi@v1.1.4
   with:
-    version: '1.0.0'
-    binary-checksum: '<sha256-checksum>'
+    binary-checksum: '80f66f194d2950f791cfcc84707ac82c7aa623dab4cf836d69ac1982453e3d84'
 ```
 
 ### Cache behavior

--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ For the archive
     archive-checksum: '65586fb53f36b989636d2e83e27316d788056835cc7f8e6e38ba445fb17d9b43'
 ```
 
+<details>
+<summary>Archive checksums for all supported targets</summary>
+
+| Target | Archive checksum |
+|--------|----------|
+| `aarch64-apple-darwin` | `db11c9c7e0b3d628ce62040f2e4be3cdacb808193de30959dbc48ad7250c3926` |
+| `aarch64-pc-windows-msvc` | `f3ccf5813776f2202d8ee5258298c604f700c588f3ef3a974b0b85b2c864db29` |
+| `aarch64-unknown-linux-musl` | `2f0242007c7723706b2c62bb07fc1351ffd9604bf45bfedde68f8588c61d260f` |
+| `arm-unknown-linux-gnueabihf` | `e512e2730ac2599ba3a7692575cc2748e714dfab6a315c4e6cbebbd0a314fd5e` |
+| `x86_64-apple-darwin` | `6dbc29396ee4c85bb73dcc67dd398772964bf2fca4ba671bed31e80fefe8a93a` |
+| `x86_64-pc-windows-msvc` | `6a62ddbfda2e32a59e05fdab6d93a9c33938e0f0ae05594cad8666a81d91eef7` |
+| `x86_64-unknown-linux-musl` | `65586fb53f36b989636d2e83e27316d788056835cc7f8e6e38ba445fb17d9b43` |
+
+</details>
+
 For the executable binary
 
 ```yaml
@@ -49,19 +64,20 @@ For the executable binary
 ```
 
 <details>
-<summary>Checksums for all supported targets</summary>
+<summary>Executable binary checksums for all supported targets</summary>
 
-| Target | Archive checksum | Binary checksum |
-|--------|------------------|-----------------|
-| `aarch64-apple-darwin` | `db11c9c7e0b3d628ce62040f2e4be3cdacb808193de30959dbc48ad7250c3926` | `cf26e34d83c54a899329df045e7cb22b798106aa78793cd13985cf5657214769` |
-| `aarch64-pc-windows-msvc` | `f3ccf5813776f2202d8ee5258298c604f700c588f3ef3a974b0b85b2c864db29` | `dd2233f1d9a94f7f14c7fe07def06b83e3b2c91e85c87dc0af80f6fe06e87841` |
-| `aarch64-unknown-linux-musl` | `2f0242007c7723706b2c62bb07fc1351ffd9604bf45bfedde68f8588c61d260f` | `229ca39a1733b4eb475f35445e2f378431843d485e450e8584288db23aaec21b` |
-| `arm-unknown-linux-gnueabihf` | `e512e2730ac2599ba3a7692575cc2748e714dfab6a315c4e6cbebbd0a314fd5e` | `30a8bfe889be54accddd456240e58360d28e0739e08218ca811699523e11df91` |
-| `x86_64-apple-darwin` | `6dbc29396ee4c85bb73dcc67dd398772964bf2fca4ba671bed31e80fefe8a93a` | `c2b06ab294a3130f9b1b4466622261f24db1a0ae8a3769ccf9e3d38bbf8206a8` |
-| `x86_64-pc-windows-msvc` | `6a62ddbfda2e32a59e05fdab6d93a9c33938e0f0ae05594cad8666a81d91eef7` | `725e022cc7d5053c448ec790f27d44b8327970b1a2d7cb3723dae4b81451cd5c` |
-| `x86_64-unknown-linux-musl` | `65586fb53f36b989636d2e83e27316d788056835cc7f8e6e38ba445fb17d9b43` | `80f66f194d2950f791cfcc84707ac82c7aa623dab4cf836d69ac1982453e3d84` |
+| Target | Binary checksum |
+|--------|----------|
+| `aarch64-apple-darwin` | `cf26e34d83c54a899329df045e7cb22b798106aa78793cd13985cf5657214769` |
+| `aarch64-pc-windows-msvc` | `dd2233f1d9a94f7f14c7fe07def06b83e3b2c91e85c87dc0af80f6fe06e87841` |
+| `aarch64-unknown-linux-musl` | `229ca39a1733b4eb475f35445e2f378431843d485e450e8584288db23aaec21b` |
+| `arm-unknown-linux-gnueabihf` | `30a8bfe889be54accddd456240e58360d28e0739e08218ca811699523e11df91` |
+| `x86_64-apple-darwin` | `c2b06ab294a3130f9b1b4466622261f24db1a0ae8a3769ccf9e3d38bbf8206a8` |
+| `x86_64-pc-windows-msvc` | `725e022cc7d5053c448ec790f27d44b8327970b1a2d7cb3723dae4b81451cd5c` |
+| `x86_64-unknown-linux-musl` | `80f66f194d2950f791cfcc84707ac82c7aa623dab4cf836d69ac1982453e3d84` |
 
 </details>
+
 
 ### Cache behavior
 - `true`: always enables cache.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ For the executable binary
     binary-checksum: '80f66f194d2950f791cfcc84707ac82c7aa623dab4cf836d69ac1982453e3d84'
 ```
 
+<details>
+<summary>Checksums for all supported targets</summary>
+
+| Target | Archive checksum | Binary checksum |
+|--------|------------------|-----------------|
+| `aarch64-apple-darwin` | `db11c9c7e0b3d628ce62040f2e4be3cdacb808193de30959dbc48ad7250c3926` | `cf26e34d83c54a899329df045e7cb22b798106aa78793cd13985cf5657214769` |
+| `aarch64-pc-windows-msvc` | `f3ccf5813776f2202d8ee5258298c604f700c588f3ef3a974b0b85b2c864db29` | `dd2233f1d9a94f7f14c7fe07def06b83e3b2c91e85c87dc0af80f6fe06e87841` |
+| `aarch64-unknown-linux-musl` | `2f0242007c7723706b2c62bb07fc1351ffd9604bf45bfedde68f8588c61d260f` | `229ca39a1733b4eb475f35445e2f378431843d485e450e8584288db23aaec21b` |
+| `arm-unknown-linux-gnueabihf` | `e512e2730ac2599ba3a7692575cc2748e714dfab6a315c4e6cbebbd0a314fd5e` | `30a8bfe889be54accddd456240e58360d28e0739e08218ca811699523e11df91` |
+| `x86_64-apple-darwin` | `6dbc29396ee4c85bb73dcc67dd398772964bf2fca4ba671bed31e80fefe8a93a` | `c2b06ab294a3130f9b1b4466622261f24db1a0ae8a3769ccf9e3d38bbf8206a8` |
+| `x86_64-pc-windows-msvc` | `6a62ddbfda2e32a59e05fdab6d93a9c33938e0f0ae05594cad8666a81d91eef7` | `725e022cc7d5053c448ec790f27d44b8327970b1a2d7cb3723dae4b81451cd5c` |
+| `x86_64-unknown-linux-musl` | `65586fb53f36b989636d2e83e27316d788056835cc7f8e6e38ba445fb17d9b43` | `80f66f194d2950f791cfcc84707ac82c7aa623dab4cf836d69ac1982453e3d84` |
+
+</details>
+
 ### Cache behavior
 - `true`: always enables cache.
 - `false`: always disables cache.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For the archive
 ```
 
 <details>
-<summary>Archive checksums for all supported targets</summary>
+<summary>🔐 Archive checksums for all supported targets</summary>
 
 | Target | Archive checksum |
 |--------|----------|
@@ -64,7 +64,7 @@ For the executable binary
 ```
 
 <details>
-<summary>Executable binary checksums for all supported targets</summary>
+<summary>🔐 Executable binary checksums for all supported targets</summary>
 
 | Target | Binary checksum |
 |--------|----------|
@@ -77,7 +77,6 @@ For the executable binary
 | `x86_64-unknown-linux-musl` | `80f66f194d2950f791cfcc84707ac82c7aa623dab4cf836d69ac1982453e3d84` |
 
 </details>
-
 
 ### Cache behavior
 - `true`: always enables cache.

--- a/update_version.py
+++ b/update_version.py
@@ -5,15 +5,26 @@ import io
 import re
 import tarfile
 import urllib.request
+import zipfile
 from dataclasses import dataclass
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent
-CHECKSUM_TARGET = "x86_64-unknown-linux-musl"
+DEFAULT_CHECKSUM_TARGET = "x86_64-unknown-linux-musl"
+CHECKSUM_TARGETS = (
+    ("aarch64-apple-darwin", "tar.gz", "tombi"),
+    ("aarch64-pc-windows-msvc", "zip", "tombi.exe"),
+    ("aarch64-unknown-linux-musl", "tar.gz", "tombi"),
+    ("arm-unknown-linux-gnueabihf", "tar.gz", "tombi"),
+    ("x86_64-apple-darwin", "tar.gz", "tombi"),
+    ("x86_64-pc-windows-msvc", "zip", "tombi.exe"),
+    ("x86_64-unknown-linux-musl", "tar.gz", "tombi"),
+)
 
 
 @dataclass(frozen=True)
 class ReleaseChecksums:
+    target: str
     archive: str
     binary: str
 
@@ -41,10 +52,10 @@ def sha256_hex(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
 
-def find_binary_in_tar_gz(archive_content: bytes) -> bytes:
+def find_binary_in_tar_gz(archive_content: bytes, binary_name: str) -> bytes:
     with tarfile.open(fileobj=io.BytesIO(archive_content), mode="r:gz") as archive:
         for member in archive.getmembers():
-            if not member.isfile() or Path(member.name).name != "tombi":
+            if not member.isfile() or Path(member.name).name != binary_name:
                 continue
 
             binary_file = archive.extractfile(member)
@@ -52,11 +63,39 @@ def find_binary_in_tar_gz(archive_content: bytes) -> bytes:
                 break
             return binary_file.read()
 
-    raise RuntimeError("Could not find tombi binary in release archive")
+    raise RuntimeError(f"Could not find {binary_name} in release archive")
 
 
-def fetch_release_checksums(version: str) -> ReleaseChecksums:
-    archive_name = f"tombi-cli-{version}-{CHECKSUM_TARGET}.tar.gz"
+def find_binary_in_zip(archive_content: bytes, binary_name: str) -> bytes:
+    with zipfile.ZipFile(io.BytesIO(archive_content)) as archive:
+        for member_name in archive.namelist():
+            if Path(member_name).name != binary_name:
+                continue
+            return archive.read(member_name)
+
+    raise RuntimeError(f"Could not find {binary_name} in release archive")
+
+
+def find_binary_in_archive(
+    archive_content: bytes,
+    archive_format: str,
+    binary_name: str,
+) -> bytes:
+    if archive_format == "tar.gz":
+        return find_binary_in_tar_gz(archive_content, binary_name)
+    if archive_format == "zip":
+        return find_binary_in_zip(archive_content, binary_name)
+
+    raise RuntimeError(f"Unsupported archive format: {archive_format}")
+
+
+def fetch_release_checksums_for_target(
+    version: str,
+    target: str,
+    archive_format: str,
+    binary_name: str,
+) -> ReleaseChecksums:
+    archive_name = f"tombi-cli-{version}-{target}.{archive_format}"
     archive_url = (
         f"https://github.com/tombi-toml/tombi/releases/download/v{version}/{archive_name}"
     )
@@ -65,11 +104,43 @@ def fetch_release_checksums(version: str) -> ReleaseChecksums:
     with urllib.request.urlopen(archive_url, timeout=60) as response:
         archive_content = response.read()
 
-    binary_content = find_binary_in_tar_gz(archive_content)
+    binary_content = find_binary_in_archive(
+        archive_content,
+        archive_format,
+        binary_name,
+    )
     return ReleaseChecksums(
+        target=target,
         archive=sha256_hex(archive_content),
         binary=sha256_hex(binary_content),
     )
+
+
+def fetch_release_checksums(version: str) -> list[ReleaseChecksums]:
+    return [
+        fetch_release_checksums_for_target(version, target, archive_format, binary_name)
+        for target, archive_format, binary_name in CHECKSUM_TARGETS
+    ]
+
+
+def default_release_checksums(checksums: list[ReleaseChecksums]) -> ReleaseChecksums:
+    for checksum in checksums:
+        if checksum.target == DEFAULT_CHECKSUM_TARGET:
+            return checksum
+
+    raise RuntimeError(f"Could not find checksums for {DEFAULT_CHECKSUM_TARGET}")
+
+
+def render_checksum_table(checksums: list[ReleaseChecksums]) -> str:
+    rows = [
+        "| Target | Archive checksum | Binary checksum |",
+        "|--------|------------------|-----------------|",
+    ]
+    rows.extend(
+        f"| `{checksum.target}` | `{checksum.archive}` | `{checksum.binary}` |"
+        for checksum in checksums
+    )
+    return "\n".join(rows)
 
 
 def update_package_json(new_version: str) -> bool:
@@ -93,9 +164,10 @@ def update_package_json(new_version: str) -> bool:
     return True
 
 
-def update_readme(new_version: str, checksums: ReleaseChecksums) -> bool:
+def update_readme(new_version: str, checksums: list[ReleaseChecksums]) -> bool:
     readme_path = REPO_ROOT / "README.md"
     readme_content = readme_path.read_text()
+    default_checksums = default_release_checksums(checksums)
 
     version_match = re.search(
         r"uses: tombi-toml/setup-tombi@v(\d+\.\d+\.\d+)", readme_content
@@ -116,7 +188,7 @@ def update_readme(new_version: str, checksums: ReleaseChecksums) -> bool:
 
     updated_content, archive_replacements = re.subn(
         r"(?m)^(?:    version: '[^']+'\n)?    archive-checksum: '[^']+'$",
-        f"    archive-checksum: '{checksums.archive}'",
+        f"    archive-checksum: '{default_checksums.archive}'",
         updated_content,
     )
     if archive_replacements != 1:
@@ -124,11 +196,46 @@ def update_readme(new_version: str, checksums: ReleaseChecksums) -> bool:
 
     updated_content, binary_replacements = re.subn(
         r"(?m)^(?:    version: '[^']+'\n)?    binary-checksum: '[^']+'$",
-        f"    binary-checksum: '{checksums.binary}'",
+        f"    binary-checksum: '{default_checksums.binary}'",
         updated_content,
     )
     if binary_replacements != 1:
         raise RuntimeError("Could not update binary-checksum example in README.md")
+
+    checksum_table = render_checksum_table(checksums)
+    checksum_details = (
+        "<details>\n"
+        "<summary>Checksums for all supported targets</summary>\n\n"
+        f"{checksum_table}\n\n"
+        "</details>\n"
+    )
+    details_pattern = (
+        r"(?s)<details>\n"
+        r"<summary>Checksums for all supported targets</summary>\n\n"
+        r".*?\n"
+        r"</details>"
+    )
+    updated_content, details_replacements = re.subn(
+        details_pattern,
+        checksum_details,
+        updated_content,
+    )
+    if details_replacements == 0:
+        insert_after = (
+            r"(?s)(```yaml\n"
+            r"- uses: tombi-toml/setup-tombi@v\d+\.\d+\.\d+\n"
+            r"  with:\n"
+            r"    binary-checksum: '[^']+'\n"
+            r"```\n)"
+        )
+        updated_content, details_replacements = re.subn(
+            insert_after,
+            rf"\1\n{checksum_details}",
+            updated_content,
+            count=1,
+        )
+    if details_replacements != 1:
+        raise RuntimeError("Could not update checksum details in README.md")
 
     if updated_content == readme_content:
         return False

--- a/update_version.py
+++ b/update_version.py
@@ -131,15 +131,18 @@ def default_release_checksums(checksums: list[ReleaseChecksums]) -> ReleaseCheck
     raise RuntimeError(f"Could not find checksums for {DEFAULT_CHECKSUM_TARGET}")
 
 
-def render_checksum_table(checksums: list[ReleaseChecksums]) -> str:
+def render_checksum_table(
+    checksums: list[ReleaseChecksums],
+    checksum_field: str,
+    checksum_label: str,
+) -> str:
     rows = [
-        "| Target | Archive checksum | Binary checksum |",
-        "|--------|------------------|-----------------|",
+        f"| Target | {checksum_label} |",
+        "|--------|----------|",
     ]
-    rows.extend(
-        f"| `{checksum.target}` | `{checksum.archive}` | `{checksum.binary}` |"
-        for checksum in checksums
-    )
+    for checksum in checksums:
+        value = getattr(checksum, checksum_field)
+        rows.append(f"| `{checksum.target}` | `{value}` |")
     return "\n".join(rows)
 
 
@@ -202,40 +205,80 @@ def update_readme(new_version: str, checksums: list[ReleaseChecksums]) -> bool:
     if binary_replacements != 1:
         raise RuntimeError("Could not update binary-checksum example in README.md")
 
-    checksum_table = render_checksum_table(checksums)
-    checksum_details = (
+    archive_details = (
         "<details>\n"
-        "<summary>Checksums for all supported targets</summary>\n\n"
-        f"{checksum_table}\n\n"
+        "<summary>Archive checksums for all supported targets</summary>\n\n"
+        f"{render_checksum_table(checksums, 'archive', 'Archive checksum')}\n\n"
         "</details>\n"
     )
-    details_pattern = (
-        r"(?s)<details>\n"
-        r"<summary>Checksums for all supported targets</summary>\n\n"
-        r".*?\n"
-        r"</details>"
+    binary_details = (
+        "<details>\n"
+        "<summary>Executable binary checksums for all supported targets</summary>\n\n"
+        f"{render_checksum_table(checksums, 'binary', 'Binary checksum')}\n\n"
+        "</details>\n"
     )
-    updated_content, details_replacements = re.subn(
-        details_pattern,
-        checksum_details,
+
+    legacy_details_pattern = (
+        r"\n<details>\n"
+        r"<summary>Checksums for all supported targets</summary>\n\n"
+        r"(?s:.*?)\n"
+        r"</details>\n?"
+    )
+    updated_content = re.sub(
+        legacy_details_pattern,
+        "\n",
         updated_content,
     )
-    if details_replacements == 0:
-        insert_after = (
-            r"(?s)(```yaml\n"
-            r"- uses: tombi-toml/setup-tombi@v\d+\.\d+\.\d+\n"
-            r"  with:\n"
-            r"    binary-checksum: '[^']+'\n"
-            r"```\n)"
-        )
-        updated_content, details_replacements = re.subn(
-            insert_after,
-            rf"\1\n{checksum_details}",
-            updated_content,
-            count=1,
-        )
-    if details_replacements != 1:
-        raise RuntimeError("Could not update checksum details in README.md")
+
+    archive_details_pattern = (
+        r"(?s)\n<details>\n"
+        r"<summary>Archive checksums for all supported targets</summary>\n\n"
+        r".*?\n"
+        r"</details>\n?"
+    )
+    updated_content = re.sub(archive_details_pattern, "\n", updated_content)
+
+    binary_details_pattern = (
+        r"(?s)\n<details>\n"
+        r"<summary>Executable binary checksums for all supported targets</summary>\n\n"
+        r".*?\n"
+        r"</details>\n?"
+    )
+    updated_content = re.sub(binary_details_pattern, "\n", updated_content)
+
+    archive_insert_after = (
+        r"(?s)(For the archive\n\n"
+        r"```yaml\n"
+        r"- uses: tombi-toml/setup-tombi@v\d+\.\d+\.\d+\n"
+        r"  with:\n"
+        r"    archive-checksum: '[^']+'\n"
+        r"```\n)"
+    )
+    updated_content, archive_details_replacements = re.subn(
+        archive_insert_after,
+        rf"\1\n{archive_details}",
+        updated_content,
+        count=1,
+    )
+    if archive_details_replacements != 1:
+        raise RuntimeError("Could not update archive checksum details in README.md")
+
+    binary_insert_after = (
+        r"(?s)(For the executable binary\n\n"
+        r"```yaml\n"
+        r"- uses: tombi-toml/setup-tombi@v\d+\.\d+\.\d+\n"
+        r"  with:\n"
+        r"    binary-checksum: '[^']+'\n"
+        r"```\n)"
+    )
+    updated_content, binary_details_replacements = re.subn(
+        binary_insert_after,
+        rf"\1\n{binary_details}",
+        updated_content,
+        count=1,
+    )
+    if binary_details_replacements != 1:
+        raise RuntimeError("Could not update binary checksum details in README.md")
 
     if updated_content == readme_content:
         return False

--- a/update_version.py
+++ b/update_version.py
@@ -207,13 +207,13 @@ def update_readme(new_version: str, checksums: list[ReleaseChecksums]) -> bool:
 
     archive_details = (
         "<details>\n"
-        "<summary>Archive checksums for all supported targets</summary>\n\n"
+        "<summary>🔐 Archive checksums for all supported targets</summary>\n\n"
         f"{render_checksum_table(checksums, 'archive', 'Archive checksum')}\n\n"
         "</details>\n"
     )
     binary_details = (
         "<details>\n"
-        "<summary>Executable binary checksums for all supported targets</summary>\n\n"
+        "<summary>🔐 Executable binary checksums for all supported targets</summary>\n\n"
         f"{render_checksum_table(checksums, 'binary', 'Binary checksum')}\n\n"
         "</details>\n"
     )
@@ -222,7 +222,7 @@ def update_readme(new_version: str, checksums: list[ReleaseChecksums]) -> bool:
         r"\n<details>\n"
         r"<summary>Checksums for all supported targets</summary>\n\n"
         r"(?s:.*?)\n"
-        r"</details>\n?"
+        r"</details>\n*"
     )
     updated_content = re.sub(
         legacy_details_pattern,
@@ -232,17 +232,17 @@ def update_readme(new_version: str, checksums: list[ReleaseChecksums]) -> bool:
 
     archive_details_pattern = (
         r"(?s)\n<details>\n"
-        r"<summary>Archive checksums for all supported targets</summary>\n\n"
+        r"<summary>(?:🔐 )?Archive checksums for all supported targets</summary>\n\n"
         r".*?\n"
-        r"</details>\n?"
+        r"</details>\n*"
     )
     updated_content = re.sub(archive_details_pattern, "\n", updated_content)
 
     binary_details_pattern = (
         r"(?s)\n<details>\n"
-        r"<summary>Executable binary checksums for all supported targets</summary>\n\n"
+        r"<summary>(?:🔐 )?Executable binary checksums for all supported targets</summary>\n\n"
         r".*?\n"
-        r"</details>\n?"
+        r"</details>\n*"
     )
     updated_content = re.sub(binary_details_pattern, "\n", updated_content)
 

--- a/update_version.py
+++ b/update_version.py
@@ -1,9 +1,21 @@
 import json
 import argparse
+import hashlib
+import io
 import re
+import tarfile
+import urllib.request
+from dataclasses import dataclass
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent
+CHECKSUM_TARGET = "x86_64-unknown-linux-musl"
+
+
+@dataclass(frozen=True)
+class ReleaseChecksums:
+    archive: str
+    binary: str
 
 
 def parse_args() -> argparse.Namespace:
@@ -23,6 +35,41 @@ def normalize_version(version: str) -> str:
 def read_package_version() -> str:
     package_json_path = REPO_ROOT / "package.json"
     return json.loads(package_json_path.read_text())["version"]
+
+
+def sha256_hex(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def find_binary_in_tar_gz(archive_content: bytes) -> bytes:
+    with tarfile.open(fileobj=io.BytesIO(archive_content), mode="r:gz") as archive:
+        for member in archive.getmembers():
+            if not member.isfile() or Path(member.name).name != "tombi":
+                continue
+
+            binary_file = archive.extractfile(member)
+            if binary_file is None:
+                break
+            return binary_file.read()
+
+    raise RuntimeError("Could not find tombi binary in release archive")
+
+
+def fetch_release_checksums(version: str) -> ReleaseChecksums:
+    archive_name = f"tombi-cli-{version}-{CHECKSUM_TARGET}.tar.gz"
+    archive_url = (
+        f"https://github.com/tombi-toml/tombi/releases/download/v{version}/{archive_name}"
+    )
+
+    print(f"Downloading {archive_url}")
+    with urllib.request.urlopen(archive_url, timeout=60) as response:
+        archive_content = response.read()
+
+    binary_content = find_binary_in_tar_gz(archive_content)
+    return ReleaseChecksums(
+        archive=sha256_hex(archive_content),
+        binary=sha256_hex(binary_content),
+    )
 
 
 def update_package_json(new_version: str) -> bool:
@@ -46,7 +93,7 @@ def update_package_json(new_version: str) -> bool:
     return True
 
 
-def update_readme(new_version: str) -> bool:
+def update_readme(new_version: str, checksums: ReleaseChecksums) -> bool:
     readme_path = REPO_ROOT / "README.md"
     readme_content = readme_path.read_text()
 
@@ -66,6 +113,23 @@ def update_readme(new_version: str) -> bool:
     )
     if replacements == 0:
         raise RuntimeError("Could not find setup-tombi version references in README.md")
+
+    updated_content, archive_replacements = re.subn(
+        r"(?m)^(?:    version: '[^']+'\n)?    archive-checksum: '[^']+'$",
+        f"    archive-checksum: '{checksums.archive}'",
+        updated_content,
+    )
+    if archive_replacements != 1:
+        raise RuntimeError("Could not update archive-checksum example in README.md")
+
+    updated_content, binary_replacements = re.subn(
+        r"(?m)^(?:    version: '[^']+'\n)?    binary-checksum: '[^']+'$",
+        f"    binary-checksum: '{checksums.binary}'",
+        updated_content,
+    )
+    if binary_replacements != 1:
+        raise RuntimeError("Could not update binary-checksum example in README.md")
+
     if updated_content == readme_content:
         return False
 
@@ -80,8 +144,9 @@ def main():
     print(f"Current package version: {current_package_version}")
     print(f"Target version: {target_version}")
 
+    checksums = fetch_release_checksums(target_version)
     package_updated = update_package_json(target_version)
-    readme_updated = update_readme(target_version)
+    readme_updated = update_readme(target_version, checksums)
 
     if not package_updated and not readme_updated:
         print("Versions are already up to date")

--- a/update_version.py
+++ b/update_version.py
@@ -40,7 +40,12 @@ def parse_args() -> argparse.Namespace:
 
 
 def normalize_version(version: str) -> str:
-    return version.removeprefix("v").strip()
+    normalized_version = version.removeprefix("v").strip()
+    if not re.fullmatch(r"\d+\.\d+\.\d+", normalized_version):
+        raise RuntimeError(
+            "Version must be a semantic version in MAJOR.MINOR.PATCH format"
+        )
+    return normalized_version
 
 
 def read_package_version() -> str:
@@ -60,8 +65,10 @@ def find_binary_in_tar_gz(archive_content: bytes, binary_name: str) -> bytes:
 
             binary_file = archive.extractfile(member)
             if binary_file is None:
-                break
-            return binary_file.read()
+                continue
+
+            with binary_file:
+                return binary_file.read()
 
     raise RuntimeError(f"Could not find {binary_name} in release archive")
 
@@ -165,6 +172,39 @@ def update_package_json(new_version: str) -> bool:
 
     package_json_path.write_text(updated_content)
     return True
+
+
+def readme_needs_update(new_version: str) -> bool:
+    readme_path = REPO_ROOT / "README.md"
+    readme_content = readme_path.read_text()
+
+    if re.search(
+        r"uses: tombi-toml/setup-tombi@v(?!"
+        + re.escape(new_version)
+        + r"\b)\d+\.\d+\.\d+",
+        readme_content,
+    ):
+        return True
+
+    stale_patterns = (
+        r"archive-checksum: '<sha256-checksum>'",
+        r"binary-checksum: '<sha256-checksum>'",
+        r"(?m)^    version: '[^']+'\n    archive-checksum:",
+        r"(?m)^    version: '[^']+'\n    binary-checksum:",
+        r"<summary>Checksums for all supported targets</summary>",
+        r"<summary>Archive checksums for all supported targets</summary>",
+        r"<summary>Executable binary checksums for all supported targets</summary>",
+    )
+    if any(re.search(pattern, readme_content) for pattern in stale_patterns):
+        return True
+
+    required_patterns = (
+        r"<summary>🔐 Archive checksums for all supported targets</summary>",
+        r"<summary>🔐 Executable binary checksums for all supported targets</summary>",
+        r"archive-checksum: '[0-9a-f]{64}'",
+        r"binary-checksum: '[0-9a-f]{64}'",
+    )
+    return not all(re.search(pattern, readme_content) for pattern in required_patterns)
 
 
 def update_readme(new_version: str, checksums: list[ReleaseChecksums]) -> bool:
@@ -293,6 +333,12 @@ def main():
     current_package_version = read_package_version()
     print(f"Current package version: {current_package_version}")
     print(f"Target version: {target_version}")
+
+    package_needs_update = current_package_version != target_version
+    readme_requires_update = readme_needs_update(target_version)
+    if not package_needs_update and not readme_requires_update:
+        print("Versions are already up to date")
+        return
 
     checksums = fetch_release_checksums(target_version)
     package_updated = update_package_json(target_version)

--- a/update_version_test.py
+++ b/update_version_test.py
@@ -2,6 +2,7 @@ import io
 import tarfile
 import tempfile
 import unittest
+import zipfile
 from pathlib import Path
 
 import update_version
@@ -17,8 +18,21 @@ class UpdateVersionTest(unittest.TestCase):
             archive.addfile(member, io.BytesIO(binary_content))
 
         self.assertEqual(
-            update_version.find_binary_in_tar_gz(archive_buffer.getvalue()),
+            update_version.find_binary_in_tar_gz(archive_buffer.getvalue(), "tombi"),
             binary_content,
+        )
+
+    def test_find_binary_in_zip(self):
+        archive_buffer = io.BytesIO()
+        with zipfile.ZipFile(archive_buffer, mode="w") as archive:
+            archive.writestr(
+                "tombi-cli-1.2.3-x86_64-pc-windows-msvc/tombi.exe",
+                b"windows binary content",
+            )
+
+        self.assertEqual(
+            update_version.find_binary_in_zip(archive_buffer.getvalue(), "tombi.exe"),
+            b"windows binary content",
         )
 
     def test_update_readme_replaces_versions_and_checksum_placeholders(self):
@@ -48,10 +62,18 @@ class UpdateVersionTest(unittest.TestCase):
 
                 updated = update_version.update_readme(
                     "1.2.3",
-                    update_version.ReleaseChecksums(
-                        archive="archive-sha",
-                        binary="binary-sha",
-                    ),
+                    [
+                        update_version.ReleaseChecksums(
+                            target="aarch64-apple-darwin",
+                            archive="darwin-arm64-archive-sha",
+                            binary="darwin-arm64-binary-sha",
+                        ),
+                        update_version.ReleaseChecksums(
+                            target="x86_64-unknown-linux-musl",
+                            archive="archive-sha",
+                            binary="binary-sha",
+                        ),
+                    ],
                 )
 
                 self.assertTrue(updated)
@@ -70,6 +92,16 @@ class UpdateVersionTest(unittest.TestCase):
   with:
     binary-checksum: 'binary-sha'
 ```
+
+<details>
+<summary>Checksums for all supported targets</summary>
+
+| Target | Archive checksum | Binary checksum |
+|--------|------------------|-----------------|
+| `aarch64-apple-darwin` | `darwin-arm64-archive-sha` | `darwin-arm64-binary-sha` |
+| `x86_64-unknown-linux-musl` | `archive-sha` | `binary-sha` |
+
+</details>
 """,
                 )
             finally:
@@ -95,15 +127,32 @@ class UpdateVersionTest(unittest.TestCase):
   with:
     binary-checksum: 'old-binary-sha'
 ```
+
+<details>
+<summary>Checksums for all supported targets</summary>
+
+| Target | Archive checksum | Binary checksum |
+|--------|------------------|-----------------|
+| `x86_64-unknown-linux-musl` | `old-archive-sha` | `old-binary-sha` |
+
+</details>
 """
                 )
 
                 updated = update_version.update_readme(
                     "1.2.4",
-                    update_version.ReleaseChecksums(
-                        archive="new-archive-sha",
-                        binary="new-binary-sha",
-                    ),
+                    [
+                        update_version.ReleaseChecksums(
+                            target="aarch64-pc-windows-msvc",
+                            archive="windows-arm64-archive-sha",
+                            binary="windows-arm64-binary-sha",
+                        ),
+                        update_version.ReleaseChecksums(
+                            target="x86_64-unknown-linux-musl",
+                            archive="new-archive-sha",
+                            binary="new-binary-sha",
+                        ),
+                    ],
                 )
 
                 self.assertTrue(updated)
@@ -113,6 +162,10 @@ class UpdateVersionTest(unittest.TestCase):
                 )
                 self.assertIn(
                     "binary-checksum: 'new-binary-sha'",
+                    readme_path.read_text(),
+                )
+                self.assertIn(
+                    "| `aarch64-pc-windows-msvc` | `windows-arm64-archive-sha` | `windows-arm64-binary-sha` |",
                     readme_path.read_text(),
                 )
                 self.assertNotIn("version:", readme_path.read_text())

--- a/update_version_test.py
+++ b/update_version_test.py
@@ -44,12 +44,16 @@ class UpdateVersionTest(unittest.TestCase):
                 readme_path.write_text(
                     """# setup-tombi
 
+For the archive
+
 ```yaml
 - uses: tombi-toml/setup-tombi@v1.1.4
   with:
     version: '1.0.0'
     archive-checksum: '<sha256-checksum>'
 ```
+
+For the executable binary
 
 ```yaml
 - uses: tombi-toml/setup-tombi@v1.1.4
@@ -81,11 +85,25 @@ class UpdateVersionTest(unittest.TestCase):
                     readme_path.read_text(),
                     """# setup-tombi
 
+For the archive
+
 ```yaml
 - uses: tombi-toml/setup-tombi@v1.2.3
   with:
     archive-checksum: 'archive-sha'
 ```
+
+<details>
+<summary>Archive checksums for all supported targets</summary>
+
+| Target | Archive checksum |
+|--------|----------|
+| `aarch64-apple-darwin` | `darwin-arm64-archive-sha` |
+| `x86_64-unknown-linux-musl` | `archive-sha` |
+
+</details>
+
+For the executable binary
 
 ```yaml
 - uses: tombi-toml/setup-tombi@v1.2.3
@@ -94,12 +112,12 @@ class UpdateVersionTest(unittest.TestCase):
 ```
 
 <details>
-<summary>Checksums for all supported targets</summary>
+<summary>Executable binary checksums for all supported targets</summary>
 
-| Target | Archive checksum | Binary checksum |
-|--------|------------------|-----------------|
-| `aarch64-apple-darwin` | `darwin-arm64-archive-sha` | `darwin-arm64-binary-sha` |
-| `x86_64-unknown-linux-musl` | `archive-sha` | `binary-sha` |
+| Target | Binary checksum |
+|--------|----------|
+| `aarch64-apple-darwin` | `darwin-arm64-binary-sha` |
+| `x86_64-unknown-linux-musl` | `binary-sha` |
 
 </details>
 """,
@@ -116,11 +134,15 @@ class UpdateVersionTest(unittest.TestCase):
                 readme_path.write_text(
                     """# setup-tombi
 
+For the archive
+
 ```yaml
 - uses: tombi-toml/setup-tombi@v1.2.3
   with:
     archive-checksum: 'old-archive-sha'
 ```
+
+For the executable binary
 
 ```yaml
 - uses: tombi-toml/setup-tombi@v1.2.3
@@ -165,7 +187,11 @@ class UpdateVersionTest(unittest.TestCase):
                     readme_path.read_text(),
                 )
                 self.assertIn(
-                    "| `aarch64-pc-windows-msvc` | `windows-arm64-archive-sha` | `windows-arm64-binary-sha` |",
+                    "| `aarch64-pc-windows-msvc` | `windows-arm64-archive-sha` |",
+                    readme_path.read_text(),
+                )
+                self.assertIn(
+                    "| `aarch64-pc-windows-msvc` | `windows-arm64-binary-sha` |",
                     readme_path.read_text(),
                 )
                 self.assertNotIn("version:", readme_path.read_text())

--- a/update_version_test.py
+++ b/update_version_test.py
@@ -94,7 +94,7 @@ For the archive
 ```
 
 <details>
-<summary>Archive checksums for all supported targets</summary>
+<summary>🔐 Archive checksums for all supported targets</summary>
 
 | Target | Archive checksum |
 |--------|----------|
@@ -112,7 +112,7 @@ For the executable binary
 ```
 
 <details>
-<summary>Executable binary checksums for all supported targets</summary>
+<summary>🔐 Executable binary checksums for all supported targets</summary>
 
 | Target | Binary checksum |
 |--------|----------|

--- a/update_version_test.py
+++ b/update_version_test.py
@@ -9,6 +9,16 @@ import update_version
 
 
 class UpdateVersionTest(unittest.TestCase):
+    def test_normalize_version_rejects_invalid_versions(self):
+        with self.assertRaisesRegex(RuntimeError, "MAJOR.MINOR.PATCH"):
+            update_version.normalize_version("1.2")
+
+        with self.assertRaisesRegex(RuntimeError, "MAJOR.MINOR.PATCH"):
+            update_version.normalize_version("1.2.3-dev")
+
+    def test_normalize_version_accepts_versions_with_v_prefix(self):
+        self.assertEqual(update_version.normalize_version("v1.2.3"), "1.2.3")
+
     def test_find_binary_in_tar_gz(self):
         archive_buffer = io.BytesIO()
         with tarfile.open(fileobj=archive_buffer, mode="w:gz") as archive:
@@ -122,6 +132,76 @@ For the executable binary
 </details>
 """,
                 )
+            finally:
+                update_version.REPO_ROOT = original_repo_root
+
+    def test_readme_needs_update_returns_false_for_current_generated_form(self):
+        with tempfile.TemporaryDirectory() as directory:
+            original_repo_root = update_version.REPO_ROOT
+            try:
+                update_version.REPO_ROOT = Path(directory)
+                readme_path = update_version.REPO_ROOT / "README.md"
+                readme_path.write_text(
+                    """# setup-tombi
+
+```yaml
+- uses: tombi-toml/setup-tombi@v1.2.3
+  with:
+    archive-checksum: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+```
+
+<details>
+<summary>🔐 Archive checksums for all supported targets</summary>
+
+| Target | Archive checksum |
+|--------|----------|
+| `x86_64-unknown-linux-musl` | `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` |
+
+</details>
+
+```yaml
+- uses: tombi-toml/setup-tombi@v1.2.3
+  with:
+    binary-checksum: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+```
+
+<details>
+<summary>🔐 Executable binary checksums for all supported targets</summary>
+
+| Target | Binary checksum |
+|--------|----------|
+| `x86_64-unknown-linux-musl` | `bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb` |
+
+</details>
+"""
+                )
+
+                self.assertFalse(update_version.readme_needs_update("1.2.3"))
+            finally:
+                update_version.REPO_ROOT = original_repo_root
+
+    def test_readme_needs_update_returns_true_for_legacy_details(self):
+        with tempfile.TemporaryDirectory() as directory:
+            original_repo_root = update_version.REPO_ROOT
+            try:
+                update_version.REPO_ROOT = Path(directory)
+                readme_path = update_version.REPO_ROOT / "README.md"
+                readme_path.write_text(
+                    """# setup-tombi
+
+```yaml
+- uses: tombi-toml/setup-tombi@v1.2.3
+  with:
+    archive-checksum: '<sha256-checksum>'
+```
+
+<details>
+<summary>Checksums for all supported targets</summary>
+</details>
+"""
+                )
+
+                self.assertTrue(update_version.readme_needs_update("1.2.3"))
             finally:
                 update_version.REPO_ROOT = original_repo_root
 

--- a/update_version_test.py
+++ b/update_version_test.py
@@ -1,0 +1,124 @@
+import io
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+import update_version
+
+
+class UpdateVersionTest(unittest.TestCase):
+    def test_find_binary_in_tar_gz(self):
+        archive_buffer = io.BytesIO()
+        with tarfile.open(fileobj=archive_buffer, mode="w:gz") as archive:
+            binary_content = b"binary content"
+            member = tarfile.TarInfo("tombi-cli-1.2.3-x86_64-unknown-linux-musl/tombi")
+            member.size = len(binary_content)
+            archive.addfile(member, io.BytesIO(binary_content))
+
+        self.assertEqual(
+            update_version.find_binary_in_tar_gz(archive_buffer.getvalue()),
+            binary_content,
+        )
+
+    def test_update_readme_replaces_versions_and_checksum_placeholders(self):
+        with tempfile.TemporaryDirectory() as directory:
+            original_repo_root = update_version.REPO_ROOT
+            try:
+                update_version.REPO_ROOT = Path(directory)
+                readme_path = update_version.REPO_ROOT / "README.md"
+                readme_path.write_text(
+                    """# setup-tombi
+
+```yaml
+- uses: tombi-toml/setup-tombi@v1.1.4
+  with:
+    version: '1.0.0'
+    archive-checksum: '<sha256-checksum>'
+```
+
+```yaml
+- uses: tombi-toml/setup-tombi@v1.1.4
+  with:
+    version: '1.0.0'
+    binary-checksum: '<sha256-checksum>'
+```
+"""
+                )
+
+                updated = update_version.update_readme(
+                    "1.2.3",
+                    update_version.ReleaseChecksums(
+                        archive="archive-sha",
+                        binary="binary-sha",
+                    ),
+                )
+
+                self.assertTrue(updated)
+                self.assertEqual(
+                    readme_path.read_text(),
+                    """# setup-tombi
+
+```yaml
+- uses: tombi-toml/setup-tombi@v1.2.3
+  with:
+    archive-checksum: 'archive-sha'
+```
+
+```yaml
+- uses: tombi-toml/setup-tombi@v1.2.3
+  with:
+    binary-checksum: 'binary-sha'
+```
+""",
+                )
+            finally:
+                update_version.REPO_ROOT = original_repo_root
+
+    def test_update_readme_updates_existing_checksum_examples(self):
+        with tempfile.TemporaryDirectory() as directory:
+            original_repo_root = update_version.REPO_ROOT
+            try:
+                update_version.REPO_ROOT = Path(directory)
+                readme_path = update_version.REPO_ROOT / "README.md"
+                readme_path.write_text(
+                    """# setup-tombi
+
+```yaml
+- uses: tombi-toml/setup-tombi@v1.2.3
+  with:
+    archive-checksum: 'old-archive-sha'
+```
+
+```yaml
+- uses: tombi-toml/setup-tombi@v1.2.3
+  with:
+    binary-checksum: 'old-binary-sha'
+```
+"""
+                )
+
+                updated = update_version.update_readme(
+                    "1.2.4",
+                    update_version.ReleaseChecksums(
+                        archive="new-archive-sha",
+                        binary="new-binary-sha",
+                    ),
+                )
+
+                self.assertTrue(updated)
+                self.assertIn(
+                    "archive-checksum: 'new-archive-sha'",
+                    readme_path.read_text(),
+                )
+                self.assertIn(
+                    "binary-checksum: 'new-binary-sha'",
+                    readme_path.read_text(),
+                )
+                self.assertNotIn("version:", readme_path.read_text())
+            finally:
+                update_version.REPO_ROOT = original_repo_root
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- compute README checksum examples from matching tombi release artifacts during version updates
- keep Linux x64 archive and binary examples inline, each followed by a collapsible checksum table for all known CLI targets
- add tests for tar.gz and zip checksum extraction plus README rewrite behavior

## Validation
- `python3 -m unittest update_version_test.py`
- `python3 update_version.py --version 1.1.4`
